### PR TITLE
Refactor material queries to use UUIDs for attributes

### DIFF
--- a/src/db/other/query/query.js
+++ b/src/db/other/query/query.js
@@ -138,9 +138,9 @@ export async function selectHrUser(req, res, next) {
 export async function selectMaterial(req, res, next) {
 	const query = sql`
 		select
-			m.uuid as value,
-			concat(m.name, '-', a.name, '-', b.name, '-', c.name, '-', m.color) as label,
-			m.unit
+			m.name_uuid as value,
+			concat(mn.name, '-', a.name, '-', b.name, '-', c.name, '-', mc.name) as label,
+			mu.name
 		from
 			store.material m
 		left join
@@ -149,8 +149,16 @@ export async function selectMaterial(req, res, next) {
 			public.buyer b on a.buyer_uuid = b.uuid
 		left join
 			public.category c on m.category_uuid = c.uuid
+		LEFT JOIN
+			store.material_name mn on m.name_uuid = mn.uuid
+		LEFT JOIN
+			store.color mc on m.color_uuid = mc.uuid
+		LEFT JOIN
+			store.size ms on m.size_uuid = ms.uuid
+		LEFT JOIN
+			store.unit mu on m.unit_uuid = mu.uuid
 		order by
-			m.name
+			mn.name
 	`;
 
 	const materialPromise = db.execute(query);

--- a/src/db/store/query/issue.js
+++ b/src/db/store/query/issue.js
@@ -8,7 +8,7 @@ import * as hrSchema from '../../hr/schema.js';
 import db from '../../index.js';
 import * as publicSchema from '../../public/schema.js';
 import { decimalToNumber } from '../../variables.js';
-import { issue, material } from '../schema.js';
+import { issue, material, material_name, unit } from '../schema.js';
 
 export async function insert(req, res, next) {
 	if (!(await validateRequest(req, next))) return;
@@ -90,8 +90,10 @@ export async function selectAll(req, res, next) {
 		.select({
 			uuid: issue.uuid,
 			material_uuid: issue.material_uuid,
-			material_name: material.name,
-			material_unit: material.unit,
+			name_uuid: material.name_uuid,
+			material_name: material_name.name,
+			unit_uuid: material.unit_uuid,
+			unit_name: unit.name,
 			quantity: decimalToNumber(material.quantity),
 			article_name: publicSchema.article.name,
 			buyer_name: publicSchema.buyer.name,
@@ -118,6 +120,8 @@ export async function selectAll(req, res, next) {
 			publicSchema.buyer,
 			eq(publicSchema.article.buyer_uuid, publicSchema.buyer.uuid)
 		)
+		.leftJoin(material_name, eq(material.name_uuid, material_name.uuid))
+		.leftJoin(unit, eq(material.unit_uuid, unit.uuid))
 		.orderBy(desc(issue.created_at));
 
 	const toast = {

--- a/src/db/store/query/material.js
+++ b/src/db/store/query/material.js
@@ -8,7 +8,7 @@ import * as hrSchema from '../../hr/schema.js';
 import db from '../../index.js';
 import * as publicSchema from '../../public/schema.js';
 import { decimalToNumber } from '../../variables.js';
-import { material } from '../schema.js';
+import { material, material_name, unit, color, size } from '../schema.js';
 
 export async function insert(req, res, next) {
 	if (!(await validateRequest(req, next))) return;
@@ -90,10 +90,15 @@ export async function selectAll(req, res, next) {
 			buyer_name: publicSchema.buyer.name,
 			category_uuid: material.category_uuid,
 			category_name: publicSchema.category.name,
-			name: material.name,
-			color: material.color,
+			name_uuid: material.name_uuid,
+			material_name: material_name.name,
+			color_uuid: material.color_uuid,
+			color_name: color.name,
+			size_uuid: material.size_uuid,
+			size_name: size.name,
 			quantity: decimalToNumber(material.quantity),
-			unit: material.unit,
+			unit_uuid: material.unit_uuid,
+			unit_name: unit.name,
 			created_by: material.created_by,
 			created_by_name: hrSchema.users.name,
 			created_at: material.created_at,
@@ -114,6 +119,10 @@ export async function selectAll(req, res, next) {
 			publicSchema.buyer,
 			eq(publicSchema.article.buyer_uuid, publicSchema.buyer.uuid)
 		)
+		.leftJoin(material_name, eq(material.name_uuid, material_name.uuid))
+		.leftJoin(color, eq(material.color_uuid, color.uuid))
+		.leftJoin(size, eq(material.size_uuid, size.uuid))
+		.leftJoin(unit, eq(material.unit_uuid, unit.uuid))
 		.orderBy(desc(material.created_at));
 
 	const toast = {
@@ -139,10 +148,15 @@ export async function select(req, res, next) {
 			buyer_name: publicSchema.buyer.name,
 			category_uuid: material.category_uuid,
 			category_name: publicSchema.category.name,
-			name: material.name,
-			color: material.color,
+			name_uuid: material.name_uuid,
+			material_name: material_name.name,
+			color_uuid: material.color_uuid,
+			color_name: color.name,
+			size_uuid: material.size_uuid,
+			size_name: size.name,
 			quantity: decimalToNumber(material.quantity),
-			unit: material.unit,
+			unit_uuid: material.unit_uuid,
+			unit_name: unit.name,
 			created_by: material.created_by,
 			created_by_name: hrSchema.users.name,
 			created_at: material.created_at,
@@ -163,6 +177,10 @@ export async function select(req, res, next) {
 			publicSchema.buyer,
 			eq(publicSchema.article.buyer_uuid, publicSchema.buyer.uuid)
 		)
+		.leftJoin(material_name, eq(material.name_uuid, material_name.uuid))
+		.leftJoin(color, eq(material.color_uuid, color.uuid))
+		.leftJoin(size, eq(material.size_uuid, size.uuid))
+		.leftJoin(unit, eq(material.unit_uuid, unit.uuid))
 		.where(eq(material.uuid, req.params.uuid));
 
 	try {


### PR DESCRIPTION
Update material queries to utilize UUIDs for name, color, size, and unit fields, enhancing data integrity and consistency.