### PR TITLE
Fix receive_uuid assignment in insert function

### DIFF
--- a/src/db/store/query/receive_entry.js
+++ b/src/db/store/query/receive_entry.js
@@ -89,7 +89,7 @@ export async function insert(req, res, next) {
 
 	const receive_entry_values = {
 		uuid: req.body.uuid,
-		receive_uuid: req.params.receive_uuid,
+		receive_uuid: req.body.receive_uuid,
 		material_uuid:
 			materialResult.length === 0
 				? new_material_uuid


### PR DESCRIPTION
Correct the assignment of `receive_uuid` to use the request body instead of request parameters.