### PR TITLE
Update selectMaterial query to use 'uuid' for value selection

### DIFF
--- a/src/db/other/query/query.js
+++ b/src/db/other/query/query.js
@@ -138,7 +138,7 @@ export async function selectHrUser(req, res, next) {
 export async function selectMaterial(req, res, next) {
 	const query = sql`
 		select
-			m.name_uuid as value,
+			m.uuid as value,
 			concat(mn.name, '-', a.name, '-', b.name, '-', c.name, '-', mc.name) as label,
 			mu.name
 		from


### PR DESCRIPTION
Refactor the selectMaterial query to utilize 'uuid' instead of 'name_uuid' for improved clarity and consistency.