### PR TITLE
Refactor queries to return 'number' and enhance responses

### DIFF
--- a/src/db/commercial/query/lc.js
+++ b/src/db/commercial/query/lc.js
@@ -16,14 +16,14 @@ export async function insert(req, res, next) {
 	const lcPromise = db
 		.insert(lc)
 		.values(req.body)
-		.returning({ insertedUuid: lc.uuid });
+		.returning({ insertedLcNum: lc.number });
 
 	try {
 		const data = await lcPromise;
 		const toast = {
 			status: 201,
 			type: 'insert',
-			message: `${data[0].insertedUuid} inserted`,
+			message: `${data[0].insertedLcNum} lc inserted`,
 		};
 		return await res.status(201).json({ toast, data });
 	} catch (error) {
@@ -41,14 +41,14 @@ export async function update(req, res, next) {
 		.update(lc)
 		.set(req.body)
 		.where(eq(lc.uuid, req.params.uuid))
-		.returning({ updatedUuid: lc.uuid });
+		.returning({ updatedLcNum: lc.number });
 
 	try {
 		const data = await lcPromise;
 		const toast = {
 			status: 200,
 			type: 'update',
-			message: `${data[0].updatedUuid} updated`,
+			message: `${data[0].updatedLcNum} lc updated`,
 		};
 		return await res.status(200).json({ toast, data });
 	} catch (error) {
@@ -65,14 +65,14 @@ export async function remove(req, res, next) {
 	const lcPromise = db
 		.delete(lc)
 		.where(eq(lc.uuid, req.params.uuid))
-		.returning({ deletedUuid: lc.uuid });
+		.returning({ deletedLcNum: lc.number });
 
 	try {
 		const data = await lcPromise;
 		const toast = {
 			status: 200,
 			type: 'delete',
-			message: `${data[0].deletedUuid} deleted`,
+			message: `${data[0].deletedLcNum} lc deleted`,
 		};
 		return await res.status(200).json({ toast, data });
 	} catch (error) {

--- a/src/db/commercial/query/master_lc.js
+++ b/src/db/commercial/query/master_lc.js
@@ -16,14 +16,14 @@ export async function insert(req, res, next) {
 	const master_lcPromise = db
 		.insert(master_lc)
 		.values(req.body)
-		.returning({ insertedUuid: master_lc.uuid });
+		.returning({ insertedLcNum: master_lc.number });
 
 	try {
 		const data = await master_lcPromise;
 		const toast = {
 			status: 201,
 			type: 'insert',
-			message: `${data[0].insertedUuid} inserted`,
+			message: `${data[0].insertedLcNum} master-lc inserted`,
 		};
 		return await res.status(201).json({ toast, data });
 	} catch (error) {
@@ -41,14 +41,14 @@ export async function update(req, res, next) {
 		.update(master_lc)
 		.set(req.body)
 		.where(eq(master_lc.uuid, req.params.uuid))
-		.returning({ updatedUuid: master_lc.uuid });
+		.returning({ updatedLcNum: master_lc.number });
 
 	try {
 		const data = await master_lcPromise;
 		const toast = {
 			status: 200,
 			type: 'update',
-			message: `${data[0].updatedUuid} updated`,
+			message: `${data[0].updatedLcNum} master-lc updated`,
 		};
 		return await res.status(200).json({ toast, data });
 	} catch (error) {
@@ -65,14 +65,14 @@ export async function remove(req, res, next) {
 	const master_lcPromise = db
 		.delete(master_lc)
 		.where(eq(master_lc.uuid, req.params.uuid))
-		.returning({ deletedUuid: master_lc.uuid });
+		.returning({ deletedLcNum: master_lc.number });
 
 	try {
 		const data = await master_lcPromise;
 		const toast = {
 			status: 200,
 			type: 'delete',
-			message: `${data[0].deletedUuid} deleted`,
+			message: `${data[0].deletedLcNum} master-lc deleted`,
 		};
 		return await res.status(200).json({ toast, data });
 	} catch (error) {

--- a/src/db/store/query/material.js
+++ b/src/db/store/query/material.js
@@ -41,14 +41,25 @@ export async function update(req, res, next) {
 		.update(material)
 		.set(req.body)
 		.where(eq(material.uuid, req.params.uuid))
-		.returning({ updatedUuid: material.uuid });
+		.returning({ updatedUuid: material.name_uuid })
+		.then(async (updatedMaterial) => {
+			const updatedUuid = updatedMaterial[0].updatedUuid;
+			const materialName = await db
+				.select(material_name.name)
+				.from(material_name)
+				.where(eq(material_name.uuid, updatedUuid));
+			return {
+				updatedUuid,
+				materialName: materialName[0].name,
+			};
+		});
 
 	try {
 		const data = await materialPromise;
 		const toast = {
 			status: 200,
 			type: 'update',
-			message: `${data[0].updatedUuid} updated`,
+			message: `${data.materialName} updated`,
 		};
 		return await res.status(200).json({ toast, data });
 	} catch (error) {
@@ -63,14 +74,25 @@ export async function remove(req, res, next) {
 	const materialPromise = db
 		.delete(material)
 		.where(eq(material.uuid, req.params.uuid))
-		.returning({ deletedUuid: material.uuid });
+		.returning({ deletedUuid: material.uuid })
+		.then(async (deletedMaterial) => {
+			const deletedUuid = deletedMaterial[0].deletedUuid;
+			const materialName = await db
+				.select(material_name.name)
+				.from(material_name)
+				.where(eq(material_name.uuid, deletedUuid));
+			return {
+				deletedUuid,
+				materialName: materialName[0].name,
+			};
+		});
 
 	try {
 		const data = await materialPromise;
 		const toast = {
 			status: 200,
 			type: 'delete',
-			message: `${data[0].deletedUuid} deleted`,
+			message: `${data.materialName} deleted`,
 		};
 		return await res.status(200).json({ toast, data });
 	} catch (error) {

--- a/src/db/store/query/receive_entry.js
+++ b/src/db/store/query/receive_entry.js
@@ -23,7 +23,7 @@ import {
 export async function insert(req, res, next) {
 	if (!(await validateRequest(req, next))) return;
 
-	console.log('req.body', req.body);
+	// console.log('req.body', req.body);
 	let new_material_uuid = nanoid(15);
 	console.log('new_material_uuid', new_material_uuid);
 	const {
@@ -197,9 +197,9 @@ export async function update(req, res, next) {
 	// material_uuid = materialInsertResult[0].insertedUuid;
 	//}
 
-	console.log('req.body', req.body);
+	// console.log('req.body', req.body);
 	let new_material_uuid = nanoid(15);
-	console.log('new_material_uuid', new_material_uuid);
+	// console.log('new_material_uuid', new_material_uuid);
 	const {
 		quantity,
 		created_by,
@@ -235,8 +235,8 @@ export async function update(req, res, next) {
 
 	let material_uuid = new_material_uuid;
 
-	console.log('materialResult', materialResult);
-	console.log('materialResult.length', materialResult.length);
+	// console.log('materialResult', materialResult);
+	// console.log('materialResult.length', materialResult.length);
 
 	if (materialResult.length === 0) {
 		const materialInsertPromise = db
@@ -274,7 +274,7 @@ export async function update(req, res, next) {
 		remarks,
 	};
 
-	console.log('receive_entry_values', receive_entry_values);
+	// console.log('receive_entry_values', receive_entry_values);
 
 	const receive_entryPromise = db
 		.update(receive_entry)


### PR DESCRIPTION
Refactor LC and Master-LC queries to return 'number' instead of 'uuid' and update toast messages. Enhance Material update/delete to include material name in responses. Comment out debug logs in Receive Entry.