### PR TITLE
Refactor material queries to return formatted names and filter by UUID

### DIFF
--- a/src/db/store/query/material.js
+++ b/src/db/store/query/material.js
@@ -41,25 +41,14 @@ export async function update(req, res, next) {
 		.update(material)
 		.set(req.body)
 		.where(eq(material.uuid, req.params.uuid))
-		.returning({ updatedUuid: material.name_uuid })
-		.then(async (updatedMaterial) => {
-			const updatedUuid = updatedMaterial[0].updatedUuid;
-			const materialName = await db
-				.select(material_name.name)
-				.from(material_name)
-				.where(eq(material_name.uuid, updatedUuid));
-			return {
-				updatedUuid,
-				materialName: materialName[0].name,
-			};
-		});
+		.returning({ updatedUuid: material.name_uuid });
 
 	try {
 		const data = await materialPromise;
 		const toast = {
 			status: 200,
 			type: 'update',
-			message: `${data.materialName} updated`,
+			message: `${data[0].updatedUuid} updated`,
 		};
 		return await res.status(200).json({ toast, data });
 	} catch (error) {
@@ -74,25 +63,14 @@ export async function remove(req, res, next) {
 	const materialPromise = db
 		.delete(material)
 		.where(eq(material.uuid, req.params.uuid))
-		.returning({ deletedUuid: material.uuid })
-		.then(async (deletedMaterial) => {
-			const deletedUuid = deletedMaterial[0].deletedUuid;
-			const materialName = await db
-				.select(material_name.name)
-				.from(material_name)
-				.where(eq(material_name.uuid, deletedUuid));
-			return {
-				deletedUuid,
-				materialName: materialName[0].name,
-			};
-		});
+		.returning({ deletedUuid: material.uuid });
 
 	try {
 		const data = await materialPromise;
 		const toast = {
 			status: 200,
 			type: 'delete',
-			message: `${data.materialName} deleted`,
+			message: `${data[0].deletedUuid} deleted`,
 		};
 		return await res.status(200).json({ toast, data });
 	} catch (error) {

--- a/src/db/store/query/material_name.js
+++ b/src/db/store/query/material_name.js
@@ -125,7 +125,8 @@ export async function select(req, res, next) {
 		.leftJoin(
 			hrSchema.users,
 			eq(material_name.created_by, hrSchema.users.uuid)
-		);
+		)
+		.where(eq(material_name.uuid, req.params.uuid));
 
 	try {
 		const data = await material_namePromise;

--- a/src/db/store/query/receive.js
+++ b/src/db/store/query/receive.js
@@ -21,7 +21,9 @@ export async function insert(req, res, next) {
 	const receivePromise = db
 		.insert(receive)
 		.values(req.body)
-		.returning({ insertedName: receive.commercial_invoice_number });
+		.returning({
+			insertedName: sql`concat('R', to_char(receive.created_at, 'YY'), '-', LPAD(receive.id::text, 4, '0'))`,
+		});
 
 	try {
 		const data = await receivePromise;
@@ -46,7 +48,9 @@ export async function update(req, res, next) {
 		.update(receive)
 		.set(req.body)
 		.where(eq(receive.uuid, req.params.uuid))
-		.returning({ updatedName: receive.commercial_invoice_number });
+		.returning({
+			updatedName: sql`concat('R', to_char(receive.created_at, 'YY'), '-', LPAD(receive.id::text, 4, '0'))`,
+		});
 
 	try {
 		const data = await receivePromise;
@@ -70,7 +74,9 @@ export async function remove(req, res, next) {
 	const receivePromise = db
 		.delete(receive)
 		.where(eq(receive.uuid, req.params.uuid))
-		.returning({ deletedName: receive.commercial_invoice_number });
+		.returning({
+			deletedName: sql`concat('R', to_char(receive.created_at, 'YY'), '-', LPAD(receive.id::text, 4, '0'))`,
+		});
 
 	try {
 		const data = await receivePromise;


### PR DESCRIPTION
Refactor material and receive queries to return formatted names instead of UUIDs and add filtering by UUID in the material_name query. Update toast messages to reflect these changes.