### PR TITLE
Update toast messages to display material names

### DIFF
--- a/src/db/store/query/issue.js
+++ b/src/db/store/query/issue.js
@@ -20,10 +20,19 @@ export async function insert(req, res, next) {
 
 	try {
 		const data = await issuePromise;
+		const materialPromise = db
+			.select({
+				name: material_name.name,
+			})
+			.from(material_name)
+			.leftJoin(material, eq(material_name.uuid, material.name_uuid))
+			.leftJoin(issue, eq(material.uuid, issue.material_uuid))
+			.where(eq(issue.uuid, data[0].insertedUuid));
+		const materialData = await materialPromise;
 		const toast = {
 			status: 201,
 			type: 'insert',
-			message: `${data[0].insertedUuid} inserted`,
+			message: `${materialData[0].name} issued`,
 		};
 		return await res.status(201).json({ toast, data });
 	} catch (error) {
@@ -45,10 +54,22 @@ export async function update(req, res, next) {
 
 	try {
 		const data = await issuePromise;
+
+		const materialPromise = db
+			.select({
+				name: material_name.name,
+			})
+			.from(material_name)
+			.leftJoin(material, eq(material_name.uuid, material.name_uuid))
+			.leftJoin(issue, eq(material.uuid, issue.material_uuid))
+			.where(eq(issue.uuid, data[0].updatedUuid));
+
+		const materialData = await materialPromise;
+
 		const toast = {
 			status: 200,
 			type: 'update',
-			message: `${data[0].updatedUuid} updated`,
+			message: `${materialData[0].name} updated`,
 		};
 		return await res.status(200).json({ toast, data });
 	} catch (error) {
@@ -69,10 +90,19 @@ export async function remove(req, res, next) {
 
 	try {
 		const data = await issuePromise;
+		const materialPromise = db
+			.select({
+				name: material_name.name,
+			})
+			.from(material_name)
+			.leftJoin(material, eq(material_name.uuid, material.name_uuid))
+			.leftJoin(issue, eq(material.uuid, issue.material_uuid))
+			.where(eq(issue.uuid, data[0].deletedUuid));
+		const materialData = await materialPromise;
 		const toast = {
 			status: 200,
 			type: 'delete',
-			message: `${data[0].deletedUuid} deleted`,
+			message: `${materialData[0].name} deleted`,
 		};
 		return await res.status(200).json({ toast, data });
 	} catch (error) {

--- a/src/db/store/query/material.js
+++ b/src/db/store/query/material.js
@@ -20,10 +20,18 @@ export async function insert(req, res, next) {
 
 	try {
 		const data = await materialPromise;
+		const materialPromise = db
+			.select({
+				name: material_name.name,
+			})
+			.from(material_name)
+			.leftJoin(material, eq(material_name.uuid, material.name_uuid))
+			.where(eq(material.uuid, data[0].insertedUuid));
+		const materialData = await materialPromise;
 		const toast = {
 			status: 201,
 			type: 'insert',
-			message: `${data[0].insertedName} inserted`,
+			message: `${materialData[0].name} inserted`,
 		};
 		return await res.status(201).json({ toast, data });
 	} catch (error) {
@@ -45,10 +53,18 @@ export async function update(req, res, next) {
 
 	try {
 		const data = await materialPromise;
+		const materialPromise = db
+			.select({
+				name: material_name.name,
+			})
+			.from(material_name)
+			.leftJoin(material, eq(material_name.uuid, material.name_uuid))
+			.where(eq(material.uuid, data[0].updatedUuid));
+		const materialData = await materialPromise;
 		const toast = {
 			status: 200,
 			type: 'update',
-			message: `${data[0].updatedUuid} updated`,
+			message: `${materialData[0].name} updated`,
 		};
 		return await res.status(200).json({ toast, data });
 	} catch (error) {
@@ -67,10 +83,18 @@ export async function remove(req, res, next) {
 
 	try {
 		const data = await materialPromise;
+		const materialPromise = db
+			.select({
+				name: material_name.name,
+			})
+			.from(material_name)
+			.leftJoin(material, eq(material_name.uuid, material.name_uuid))
+			.where(eq(material.uuid, data[0].deletedUuid));
+		const materialData = await materialPromise;
 		const toast = {
 			status: 200,
 			type: 'delete',
-			message: `${data[0].deletedUuid} deleted`,
+			message: `${materialData[0].name} deleted`,
 		};
 		return await res.status(200).json({ toast, data });
 	} catch (error) {

--- a/src/db/store/query/receive_entry.js
+++ b/src/db/store/query/receive_entry.js
@@ -108,10 +108,25 @@ export async function insert(req, res, next) {
 
 	try {
 		const data = await receive_entryPromise;
+
+		const materialPromise = db
+			.select({
+				name: material_name.name,
+			})
+			.from(material_name)
+			.leftJoin(material, eq(material_name.uuid, material.name_uuid))
+			.leftJoin(
+				receive_entry,
+				eq(material.uuid, receive_entry.material_uuid)
+			)
+			.where(eq(receive_entry.uuid, data[0].insertedUuid));
+
+		const materialData = await materialPromise;
+
 		const toast = {
 			status: 201,
 			type: 'insert',
-			message: `${data[0].insertedUuid} inserted`,
+			message: `${materialData[0].name} inserted`,
 		};
 		return await res.status(201).json({ toast, data });
 	} catch (error) {
@@ -299,13 +314,26 @@ export async function update(req, res, next) {
 	// }
 	try {
 		const data = await receive_entryPromise;
-		console.log('data', data);
+
+		const materialPromise = db
+			.select({
+				name: material_name.name,
+			})
+			.from(material_name)
+			.leftJoin(material, eq(material_name.uuid, material.name_uuid))
+			.leftJoin(
+				receive_entry,
+				eq(material.uuid, receive_entry.material_uuid)
+			)
+			.where(eq(receive_entry.uuid, data[0].updatedUuid));
+
+		const materialData = await materialPromise;
 
 		if (data && data.length > 0) {
 			const toast = {
 				status: 200,
 				type: 'update',
-				message: `${data[0].updatedUuid} updated`,
+				message: `${materialData[0].name} updated`,
 			};
 			return await res.status(200).json({ toast, data });
 		} else {
@@ -334,10 +362,24 @@ export async function remove(req, res, next) {
 
 	try {
 		const data = await receive_entryPromise;
+		const materialPromise = db
+			.select({
+				name: material_name.name,
+			})
+			.from(material_name)
+			.leftJoin(material, eq(material_name.uuid, material.name_uuid))
+			.leftJoin(
+				receive_entry,
+				eq(material.uuid, receive_entry.material_uuid)
+			)
+			.where(eq(receive_entry.uuid, data[0].deletedUuid));
+
+		const materialData = await materialPromise;
+
 		const toast = {
 			status: 200,
 			type: 'delete',
-			message: `${data[0].deletedUuid} deleted`,
+			message: `${materialData[0].name} deleted`,
 		};
 		return await res.status(200).json({ toast, data });
 	} catch (error) {


### PR DESCRIPTION
Toast messages in issue, material, and receive_entry queries now show material names instead of UUIDs for better clarity and user experience.